### PR TITLE
wiped out session[:order_id] on user login and logout

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -7,6 +7,7 @@ class SessionsController < ApplicationController
 
     if @user && @user.authenticate(params[:session][:password])
       session[:user_id] = @user.id
+      session[:order_id] = nil
       redirect_to user_path(@user.id)
     else
       flash.now[:errors] = "Login failed. Try again."
@@ -16,6 +17,7 @@ class SessionsController < ApplicationController
 
   def destroy
     session[:user_id] = nil
+    session[:order_id] = nil
     redirect_to root_path
   end
 


### PR DESCRIPTION
set session[:order_id] to nil when a user logs in or out, so that carts don't persist

this is a workaround to prevent users from being able to buy their own items if they added them to their cart before logging in

:tomato: 
